### PR TITLE
Add gemhunters.co to the public allowlist

### DIFF
--- a/allow/allowlist.json
+++ b/allow/allowlist.json
@@ -4367,6 +4367,7 @@
     "gem.community",
     "gem.xyz",
     "gemhub.net",
+    "gemhunters.co",
     "gemini.com",
     "gemlabs.xyz",
     "gempad.app",


### PR DESCRIPTION
The maintainer confirmed in issue #332 on July 15 that `gemhunters.co` had been removed and added to the allowlist after the scanner misclassified a Cloudflare challenge. The public allowlist never received that entry, and the daily community rebuild continues to re-add the domain.

This one-line change adds the apex domain in the documented sorted allowlist format. `python scripts/validate_json.py` passes for `allow/allowlist.json` with 12,156 entries.
