### PR TITLE
Finish purge workflow restaging after deleted shards

### DIFF
--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -105,7 +105,10 @@ jobs:
             MSG="Allowlist update: clean all lists [skip ci]"
           fi
 
-          git diff --staged --name-only > /tmp/staged_files.txt
+          # Preserve both present files and deletions before resetting onto a
+          # concurrently updated main branch. A single name list breaks when a
+          # generated shard was deleted because tar cannot archive a path that
+          # no longer exists.
           git diff --staged --name-only --diff-filter=D > /tmp/deleted_files.txt
           git diff --staged --name-only --diff-filter=d > /tmp/existing_files.txt
           if [ -s /tmp/existing_files.txt ]; then
@@ -121,11 +124,17 @@ jobs:
             if [ -s /tmp/existing_files.txt ]; then
               tar -xf /tmp/processed.tar
             fi
-            if [ -s /tmp/deleted_files.txt ]; then
-              xargs git rm -f --ignore-unmatch < /tmp/deleted_files.txt 2>/dev/null || true
-            fi
+            while IFS= read -r path; do
+              if [ -n "$path" ]; then
+                git rm -f --ignore-unmatch -- "$path"
+              fi
+            done < /tmp/deleted_files.txt
 
-            git add  2>/dev/null || true
+            while IFS= read -r path; do
+              if [ -n "$path" ]; then
+                git add -A -- "$path"
+              fi
+            done < /tmp/existing_files.txt
             if git diff --staged --quiet; then
               echo "Changes already present in remote"
               exit 0
@@ -155,4 +164,3 @@ jobs:
             git fetch --unshallow 2>/dev/null || true
             git push codeberg HEAD:${BRANCH} --force || echo "Mirror push failed, continuing"
           fi
-


### PR DESCRIPTION
PR #371 merged the gemhunters.co allowlist entry, but Purge Domain run 30387640738 failed before it could push the cleaned feeds.

Main now includes commit 521ae59f8896e7271b165406380d97c586a0337c, which correctly separates existing files from deleted shards for the archive. This branch is rebased onto that commit and fixes the remaining restaging gap: the current workflow invokes git add without a pathspec, so restored modified files are not staged after the hard reset.

This follow-up stages each exact existing path and removes each exact deleted path with pathname-safe read loops. That preserves the concurrent-update protection and ensures both regenerated content and shard deletions reach the commit.

Validation:
- actionlint parsed the workflow with shellcheck disabled, so only workflow syntax and expressions were evaluated.
- git diff --check passes.
- The branch is rebased onto current upstream main and changes only .github/workflows/purge.yml.

Once merged, please rerun failed Purge Domain workflow 30387640738 so the allowlist entry removes gemhunters.co from every generated feed.
